### PR TITLE
Add reset functionality to Blend context and UI

### DIFF
--- a/src/Blend/Context.tsx
+++ b/src/Blend/Context.tsx
@@ -42,6 +42,8 @@ interface IBlendContext {
   deleteJoin: (to_query_id: string, join_uuid: string) => void;
   // *** Added function to update only fields ***
   updateQueryFields: (uuid: string, fields: IQuery["fields"]) => void;
+  // *** Reset all queries and joins ***
+  resetAll: () => void;
   connection?: string; // Keep if used
   validateJoin: (join: IJoin) => boolean;
   validateJoins: () => IQueryJoin[];
@@ -489,6 +491,12 @@ export const BlendContextProvider = ({
     [setQueries, setSelectedQuery]
   ); // Added dependencies
 
+  const resetAll = () => {
+    setQueries([]);
+    setJoins({});
+    setSelectedQuery(null);
+  };
+
   // --- Keep deleteQuery as updated previously (with field resets) ---
   const deleteQuery = useCallback(
     (uuidToDelete: string) => {
@@ -674,6 +682,7 @@ export const BlendContextProvider = ({
         deleteJoin,
         selectQuery, // Pass object-accepting selectQuery
         updateQueryFields, // Pass new function
+        resetAll, // Pass reset function
         validateJoin,
         validateJoins,
         first_query_connection,

--- a/src/Blend/ResetButton.tsx
+++ b/src/Blend/ResetButton.tsx
@@ -1,0 +1,37 @@
+import { IconButton, Tooltip } from "@looker/components";
+import { Refresh as Reset } from "@styled-icons/material";
+import React from "react";
+import { useBlendContext } from "./Context";
+
+const ResetButton: React.FC = () => {
+  const { queries, joins, resetAll } = useBlendContext();
+
+  const handleReset = () => {
+    if (
+      window.confirm(
+        "Are you sure you want to reset all queries and joins? This action cannot be undone."
+      )
+    ) {
+      resetAll();
+    }
+  };
+
+  // Don't show the button if there are no queries or joins
+  if (queries.length === 0 && Object.keys(joins).length === 0) {
+    return null;
+  }
+
+  return (
+    <Tooltip content="Reset all queries and joins">
+      <IconButton
+        icon={<Reset />}
+        onClick={handleReset}
+        size="small"
+        label="Reset"
+        aria-label="Reset all queries and joins"
+      />
+    </Tooltip>
+  );
+};
+
+export default ResetButton;

--- a/src/Blend/index.tsx
+++ b/src/Blend/index.tsx
@@ -23,6 +23,7 @@ import { BlendContextProvider, useBlendContext } from "./Context";
 import NewExplore from "./NewExplore";
 import NoQueries from "./NoQueries";
 import { QueryList } from "./QueryList";
+import ResetButton from "./ResetButton";
 import SelectedQuery from "./SelectedQuery";
 interface BlendProps {}
 
@@ -48,6 +49,7 @@ const Blend: React.FC<BlendProps> = () => {
             <Space between mb="medium" align="center">
               <Heading as="h3">{APP_NAME}</Heading>
               <Space gap="none" width="fit-content">
+                <ResetButton />
                 <SettingsIconButton />
                 <LearnMoreInfoButton />
               </Space>


### PR DESCRIPTION
- Introduce a new `resetAll` function in the Blend context to clear queries, joins, and the selected query.
- Add a `ResetButton` component in the Blend UI for user-triggered resets, enhancing user experience by allowing easy state management.

Closes #54 